### PR TITLE
Implement new file upload method

### DIFF
--- a/SN.Application/Interfaces/ISlackApiService.cs
+++ b/SN.Application/Interfaces/ISlackApiService.cs
@@ -1,7 +1,12 @@
-﻿namespace SN.Application.Interfaces;
+﻿using SN.Core.ValueObjects;
+
+namespace SN.Application.Interfaces;
 
 public interface ISlackApiService
 {
     Task<HttpResponseMessage> SendMessage(StringContent requestBody);
     Task<HttpResponseMessage> UploadFile(MultipartFormDataContent formData);
+    Task<HttpResponseMessage> GetUploadUrlAsync(string fileType, string filename, long filesize);
+    Task<HttpResponseMessage> UploadFileAsync(string uploadUrl, byte[] fileBytes);
+    Task<HttpResponseMessage> CompleteUploadAsync(string fileId, string filename, string messageThread);
 }

--- a/SN.Application/Interfaces/ISlackApiService.cs
+++ b/SN.Application/Interfaces/ISlackApiService.cs
@@ -8,5 +8,5 @@ public interface ISlackApiService
     Task<HttpResponseMessage> UploadFile(MultipartFormDataContent formData);
     Task<HttpResponseMessage> GetUploadUrlAsync(string fileType, string filename, long filesize);
     Task<HttpResponseMessage> UploadFileAsync(string uploadUrl, byte[] fileBytes);
-    Task<HttpResponseMessage> CompleteUploadAsync(string fileId, string filename, string messageThread);
+    Task<HttpResponseMessage> CompleteUploadAsync(Dictionary<string, string> files, string messageThread);
 }

--- a/SN.Application/Interfaces/ISlackApiService.cs
+++ b/SN.Application/Interfaces/ISlackApiService.cs
@@ -1,11 +1,8 @@
-﻿using SN.Core.ValueObjects;
-
-namespace SN.Application.Interfaces;
+﻿namespace SN.Application.Interfaces;
 
 public interface ISlackApiService
 {
     Task<HttpResponseMessage> SendMessage(StringContent requestBody);
-    Task<HttpResponseMessage> UploadFile(MultipartFormDataContent formData);
     Task<HttpResponseMessage> GetUploadUrlAsync(string fileType, string filename, long filesize);
     Task<HttpResponseMessage> UploadFileAsync(string uploadUrl, byte[] fileBytes);
     Task<HttpResponseMessage> CompleteUploadAsync(Dictionary<string, string> files, string messageThread);

--- a/SN.Console/Program.cs
+++ b/SN.Console/Program.cs
@@ -35,7 +35,6 @@ class Program
 
 
         _messageForwarder = host.Services.GetRequiredService<IMessageForwarderService>();
-        await _messageForwarder.Run();
         _timer = new Timer(DoWork, null, TimeSpan.Zero, TimeSpan.FromMinutes(30));
 
         Console.WriteLine("Console application started.");

--- a/SN.Core/ValueObjects/SlackGetUploadUrlResponse.cs
+++ b/SN.Core/ValueObjects/SlackGetUploadUrlResponse.cs
@@ -1,0 +1,24 @@
+﻿using System.Text.Json.Serialization;
+using System.Text.Json;
+
+namespace SN.Core.ValueObjects;
+
+public record SlackGetUploadUrlResponse()
+{
+    [JsonPropertyName("ok")]
+    public bool Ok { get; set; }
+
+    [JsonPropertyName("error")]
+    public string Error { get; set; }
+
+    [JsonPropertyName("upload_url")]
+    public string UploadUrl { get; set; }
+
+    [JsonPropertyName("file_id")]
+    public string FileId { get; set; }
+
+    public static SlackGetUploadUrlResponse FromJson(string json)
+    {
+        return JsonSerializer.Deserialize<SlackGetUploadUrlResponse>(json);
+    }
+};

--- a/SN.Infrastructure/Services/Slack/SlackApiEndpoints.cs
+++ b/SN.Infrastructure/Services/Slack/SlackApiEndpoints.cs
@@ -3,7 +3,6 @@
 public static class SlackApiEndpoints
 {
     public const string PostMessage = "/api/chat.postMessage";
-    public const string UploadFile = "/api/files.upload";
     public const string GetUploadUrl = "/api/files.getUploadURLExternal";
     public const string CompleteUpload = "/api/files.completeUploadExternal?";
 }

--- a/SN.Infrastructure/Services/Slack/SlackApiEndpoints.cs
+++ b/SN.Infrastructure/Services/Slack/SlackApiEndpoints.cs
@@ -4,4 +4,6 @@ public static class SlackApiEndpoints
 {
     public const string PostMessage = "/api/chat.postMessage";
     public const string UploadFile = "/api/files.upload";
+    public const string GetUploadUrl = "/api/files.getUploadURLExternal";
+    public const string CompleteUpload = "/api/files.completeUploadExternal?";
 }

--- a/SN.Infrastructure/Services/Slack/SlackApiService.cs
+++ b/SN.Infrastructure/Services/Slack/SlackApiService.cs
@@ -26,14 +26,6 @@ public class SlackApiService : ISlackApiService
         return await client.PostAsync(SlackApiEndpoints.PostMessage, requestBody);
     }
 
-    public async Task<HttpResponseMessage> UploadFile(MultipartFormDataContent formData)
-    {
-        var client = httpClientFactory.CreateClient(nameof(SlackApiService));
-        client.DefaultRequestHeaders.Add("Authorization", $"Bearer {options.Token}");
-
-        return await client.PostAsync(SlackApiEndpoints.UploadFile, formData);
-    }
-
     public async Task<HttpResponseMessage> GetUploadUrlAsync(string fileType, string filename, long filesize)
     {
         var requestUrl = $"{SlackApiEndpoints.GetUploadUrl}" +

--- a/SN.Infrastructure/Services/Slack/SlackApiService.cs
+++ b/SN.Infrastructure/Services/Slack/SlackApiService.cs
@@ -1,7 +1,13 @@
 ﻿using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
 using SN.Application.Interfaces;
 using SN.Application.Options;
 using SN.Application.Services;
+using SN.Core.ValueObjects;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Channels;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace SN.Infrastructure.Services.Slack;
 
@@ -30,5 +36,54 @@ public class SlackApiService : ISlackApiService
         client.DefaultRequestHeaders.Add("Authorization", $"Bearer {options.Token}");
 
         return await client.PostAsync(SlackApiEndpoints.UploadFile, formData);
+    }
+
+    public async Task<HttpResponseMessage> GetUploadUrlAsync(string fileType, string filename, long filesize)
+    {
+        var requestUrl = $"{SlackApiEndpoints.GetUploadUrl}" +
+                         $"?filename={filename}&" +
+                         $"length={filesize}";
+        var client = httpClientFactory.CreateClient(nameof(SlackApiService));
+        client.DefaultRequestHeaders.Add("Authorization", $"Bearer {options.Token}");
+        var response = await client.GetAsync(requestUrl);
+               
+        return response;
+    }
+
+    public async Task<HttpResponseMessage> UploadFileAsync(string uploadUrl, byte[] fileBytes)
+    {
+        var client = httpClientFactory.CreateClient(nameof(SlackApiService));
+
+        using var content = new ByteArrayContent(fileBytes);
+
+        var response = await client.PostAsync(uploadUrl, content);
+
+        return response;
+    }
+
+    public async Task<HttpResponseMessage> CompleteUploadAsync(string fileId, string filename, string messageThread)
+    {
+        var jsonObject = new JObject(
+            new JProperty("channel_id", $"{options.Destination}"),
+            new JProperty("thread_ts", $"{messageThread}"),
+            new JProperty("files",
+                new JArray(
+                    new JObject(
+                        new JProperty("id",  $"{fileId}"),
+                        new JProperty("title",  $"{filename}")
+                    )
+                )
+            )
+        );
+
+        var requestBody = new StringContent(jsonObject.ToString(), Encoding.UTF8);
+        requestBody.Headers.ContentType.MediaType = "application/json";
+        
+        //TODO: fixa om till JSON enligt https://api.slack.com/methods/files.completeUploadExternal
+        var client = httpClientFactory.CreateClient(nameof(SlackApiService));
+        client.DefaultRequestHeaders.Add("Authorization", $"Bearer {options.Token}");
+        var response = await client.PostAsync(SlackApiEndpoints.CompleteUpload, requestBody);
+
+        return response;
     }
 }

--- a/SN.UnitTests/SN.Infrastructure/SlackApiServiceTests.cs
+++ b/SN.UnitTests/SN.Infrastructure/SlackApiServiceTests.cs
@@ -25,7 +25,7 @@ public class SlackApiServiceTests : BaseTests
         var SUT = CreateSUT(httpClientFactory);
 
         // Act
-        var response = await SUT.UploadFile(formData);
+        var response = await SUT.GetUploadUrlAsync(Fixture.Create<string>(), Fixture.Create<string>(), Fixture.Create<long>());
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -48,7 +48,7 @@ public class SlackApiServiceTests : BaseTests
         var SUT = CreateSUT(httpClientFactory);
 
         // Act
-        var response = await SUT.UploadFile(formData);
+        var response = await SUT.GetUploadUrlAsync(Fixture.Create<string>(), Fixture.Create<string>(), Fixture.Create<int>());
 
         // Assert
         Assert.True(capturedRequest.Headers.Contains("Authorization"));


### PR DESCRIPTION
files.upload method in api is deprecated

have been replaced with:
/api/files.getUploadURLExternal
/api/files.completeUploadExternal