### PR TITLE
Support images in email body and compliance to deprecation of files.upload method

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,8 +51,8 @@ pipeline {
 						echo "Environment value ${SELECTION} fetched"
 						BUILDCONFIGURATION = 'Release'
                     } else {
-						echo "No selection was made, setting Development as environment"
-                        SELECTION = 'Development'
+						echo "No selection was made, setting Default as environment"
+                        SELECTION = 'Default'
 						BUILDCONFIGURATION = 'Debug'
                     }
 					echo "Configuration set to ${BUILDCONFIGURATION}"
@@ -72,6 +72,9 @@ pipeline {
             }
         }
         stage('Deploy') {
+			when {
+					expression { SELECTION != 'Default' }
+			}
 			steps {
 				script {
 					if (!fileExists(env.DEPLOYMENT_DIR)) {

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Prerequisites: Gmail account + access to Google console
 3. Enable the Gmail Api for your new project under _Enabled APIs & Services_ menu.
 4. Click on _Credentials_ menu, then on _Create Credentials_. Choose _OAuth Client ID_, then choose application type _desktop client_. Pick a name and Save.
 5. The created credential will be listed under Credentials menu. Click on it, and choose to download the credentials json.
-6. Rename the file to **googleCredentialsOAuth.json** and move it to _SN.Console_ folder **\***. 
+6. Rename the file to **GoogleSecretsDevelopment.json** and move it to _SN.Console_ folder **\***. Make a copy of it named **GoogleSecretsProduction.json** for configuration of production settings.
 7. Click _OAuth consent_ to setup authorizations for the app, during setup add the following scopes for the Gmail-api in the Scopes setup step:
    a. Non-sensitive scope: .../auth/gmail.addons.current.message.action
    b. Restricted scope: https://mail.google.com/
@@ -23,7 +23,7 @@ Prerequisites: Slack account
 2. Click on Basic information > Add features
    - Click to setup Bots. 
    - Click to setup Permissions. Copy token from _OAuth Tokens for Your Workspace_ section. Under _Scopes_ section, set the bot scopes: chat:write + files:write + remote_files:write
-3. Create a file named **secrets.json**. Contents of file as per below, fill in your details **\***. 
+3. Create a file named **SlackSecretsDevelopment.json**. Contents of file as per below, fill in your details **\***. 
    
 ```JSON
 [
@@ -34,12 +34,12 @@ Prerequisites: Slack account
   }
 ]
 ```
-4. Save the **secrets.json** file to _SN.Console_ folder.
+4. Save the **SlackSecretsDevelopment.json** file to _SN.Console_ folder. Make a copy if it named **SlackSecretsProduction.json** for configuration of production settings.
 5. Choose to _Install to Workspace_ to enable the app. A message will popup in the channel that a new integration have been created.
 6. Important! Invite your bot to your channel.
 
 ##### Setup done
-Doublecheck that the secrets.json and googleCredentials.json is in the SN.Console project.
+Doublecheck that the secrets files are in the SN.Console project.
 Build and run!
 
-___* filename can be changed in appsettings___
+___* NOTE: filenames for secrets files can be changed in appsettings___

--- a/SN.Application/Builders/SlackBlockBuilder.cs
+++ b/SN.Application/Builders/SlackBlockBuilder.cs
@@ -1,0 +1,302 @@
+﻿using System.Text;
+using System.Text.RegularExpressions;
+using SN.Application.Interfaces;
+using Newtonsoft.Json;
+
+namespace SN.Application.Builders;
+
+public class SlackBlockBuilder : ISlackBlockBuilder
+{
+    //private readonly string calendarIconUrl = "https://cdn-icons-png.freepik.com/128/9586/9586178.png";
+    //private readonly string calendarIconUrl = "https://cdn-icons-png.freepik.com/128/236/236351.png";
+    private readonly string calendarIconUrl = "https://cdn-icons-png.freepik.com/256/12406/12406800.png?ga=GA1.1.1928895700.1714931280&semt=ais_hybrid";
+    //private readonly string emailIconUrl = "https://cdn-icons-png.freepik.com/128/5068/5068746.png";
+    private readonly string emailIconUrl = "https://cdn-icons-png.freepik.com/256/11144/11144648.png?ga=GA1.1.1928895700.1714931280&semt=ais_hybrid";
+    //private readonly string subjectIcon = "https://cdn-icons-png.freepik.com/128/9821/9821502.png";
+    private readonly string subjectIcon = "https://cdn-icons-png.freepik.com/256/511/511605.png?ga=GA1.1.1928895700.1714931280&semt=ais_hybrid";
+    
+    private Blocks root = new Blocks();
+    private ContextBlock sentAtDate = null;
+    private ContextBlock sender = null;
+    private ContextBlock subject = null;
+    
+    private string messageBody = string.Empty;
+    private Dictionary<string,string> relatedFiles = new();
+    
+
+    public ISlackBlockBuilder ToChannel(string channel)
+    {
+        root.channel = channel;
+
+        return this;
+    }
+
+    public ISlackBlockBuilder WithHeaderTitle(string header)
+    {
+        root.blocks.Add(new HeaderBlock(header));
+        root.blocks.Add(new DividerBlock());
+
+        return this;
+    }
+
+    public ISlackBlockBuilder WithDivider()
+    {
+        root.blocks.Add(new DividerBlock());
+
+        return this;
+    }
+
+    public ISlackBlockBuilder WithSendDate(string date)
+    {
+        sentAtDate = new ContextBlock(calendarIconUrl, $"*Skickat: {DateTime.Parse(date).ToLocalTime()}*");
+
+        return this;
+    }
+    
+    public ISlackBlockBuilder FromSender(string sender)
+    {
+        this.sender = new ContextBlock(emailIconUrl, $"*Från: {FormatEmailLinkInFromText(sender)}*");
+
+        return this;
+    }
+    
+    public ISlackBlockBuilder WithSubject(string subject)
+    {
+        this.subject = new ContextBlock(subjectIcon, $"*Ämne: {subject}*");
+
+        return this;
+    }
+
+    public ISlackBlockBuilder WithMessageBody(string messageBody)
+    {
+        this.messageBody = messageBody;
+
+        return this;
+    }
+
+    public ISlackBlockBuilder WithRelatedFile(string fileName, string fileId)
+    {
+        relatedFiles.Add(fileName, fileId);
+
+        return this;
+    }
+
+    public ISlackBlockBuilder WithRelatedFiles(Dictionary<string, string> fileNames)
+    {
+        foreach (var file in fileNames)
+        {
+            relatedFiles.Add(file.Key, file.Value);
+        }
+
+        return this;
+    }
+
+    public StringContent Build()
+    {
+        var jsonObject = GenerateJsonString();
+        var requestBody = new StringContent(jsonObject, Encoding.UTF8);
+        requestBody.Headers.ContentType.MediaType = "application/json";
+
+        return requestBody;
+    }
+
+    private string GenerateJsonString()
+    {
+        if (sentAtDate is not null) root.blocks.Add(sentAtDate);
+        if (sender is not null) root.blocks.Add(sender);
+        if (subject is not null) root.blocks.Add(subject);
+
+        var containsEmbeddedImage = relatedFiles.Any();
+        if (containsEmbeddedImage)
+        {
+            var messageChunks = SeparateMessageBodyTextAndImageTags();
+            foreach (var item in messageChunks)
+            {
+                if (relatedFiles.TryGetValue(item, out string fileId))
+                {
+                    root.blocks.Add(new ImageFileIdBlock("file", fileId, "file"));
+                }
+                else
+                {
+                    root.blocks.Add(new SectionBlock(item));
+                }
+            }
+        }
+        else
+        {
+            root.blocks.Add(new SectionBlock(messageBody));
+        }
+
+        var stringJsonObject = JsonConvert.SerializeObject(root);
+
+        return stringJsonObject;
+    }
+
+    private List<string> SeparateMessageBodyTextAndImageTags()
+    {
+        var currentPosition = 0;
+        var separatedText = new List<string>();
+
+        foreach (var fileName in relatedFiles.Select(x => x.Key))
+        {
+            var imageTag = $"[image: {fileName}]";
+
+            var startIndex = messageBody.IndexOf(imageTag, currentPosition);
+            if (startIndex != -1)
+            {
+                if (startIndex > currentPosition)
+                {
+                    separatedText.Add(messageBody.Substring(currentPosition, startIndex - currentPosition));
+                }
+                separatedText.Add(fileName);
+                currentPosition = startIndex + imageTag.Length;
+            }
+        }
+
+        if (currentPosition < messageBody.Length)
+        {
+            separatedText.Add(messageBody.Substring(currentPosition));
+        }
+
+        return separatedText;
+    }
+
+    private string FormatEmailLinkInFromText(string text)
+    {
+        if (text.Contains('@') && text.Contains('<') && text.Contains('>'))
+        {
+            var emailPattern = @"<(.*?)>";
+            var regExMatch = Regex.Match(text, emailPattern);
+            if (regExMatch.Success)
+            {
+                var emailText = regExMatch.Groups[1].Value;
+                string replacedText = Regex.Replace(text, emailPattern, $"<mailto:{emailText}|{emailText}>");
+
+                return replacedText;
+            }
+        }
+
+        return text;
+    }
+
+    private class Blocks
+    {
+        public string channel;
+        public readonly List<object> blocks = new List<object>();
+
+        public Blocks()
+        {
+        }
+    }
+
+    private class HeaderBlock
+    {
+        public readonly string type = "header";
+        public readonly PlainTextBlock text;
+        
+        public HeaderBlock(string headerText)
+        {
+            text = new PlainTextBlock(headerText);
+        }
+    }
+
+    private class ContextBlock
+    {
+        public readonly string type = "context";
+        public readonly List<object> elements = new List<object>();
+
+        public ContextBlock(string imageUrl, string markdownText)
+        {
+            elements.Add(new ImageUrlBlock(imageUrl));
+            elements.Add(new MarkdownBlock(markdownText));
+        }
+
+    }
+    
+    private class SectionBlock
+    {
+        public readonly string type = "section";
+        public readonly MarkdownBlock text;
+
+        public SectionBlock(string markdownText)
+        {
+            text = new MarkdownBlock(markdownText);
+        }
+    }
+
+    private class MarkdownBlock
+    {
+        public readonly string type = "mrkdwn";
+        public readonly string text;
+
+        public MarkdownBlock(string markdownText)
+        {
+            text = markdownText;
+        }
+    }
+
+    private class ImageUrlBlock
+    {
+        public readonly string type = "image";
+        public readonly string image_url;
+        public readonly string alt_text = "bild";
+
+        public ImageUrlBlock(string imageUrl)
+        {
+            image_url = imageUrl;
+        }
+    }
+
+    private class ImageFileIdBlock
+    {
+        public readonly string type = "image";
+        public readonly PlainTextBlock title;
+        public readonly SlackFileBlock slack_file;
+        public readonly string alt_text;
+
+        public ImageFileIdBlock(string title, string fileId, string altText)
+        {
+            this.title = new PlainTextBlock(title);
+            slack_file = new SlackFileBlock(fileId);
+            alt_text = altText;
+        }
+    }
+
+    private class SlackFileBlock
+    {
+        public readonly string id;
+
+        public SlackFileBlock(string fileId)
+        {
+            id = fileId;
+        }
+    }
+
+    private class PlainTextBlock
+    {
+        public readonly string type = "plain_text";
+        public readonly string text;
+
+        public PlainTextBlock(string text)
+        {
+            this.text = text;
+        }
+    }
+
+    private class TextBlock
+    {
+        public readonly string type = "text";
+        public readonly string text;
+
+        public TextBlock(string text)
+        {
+            this.text = text;
+        }
+    }
+
+    private class DividerBlock
+    {
+        public readonly string type = "divider";
+
+    }
+}

--- a/SN.Application/Dtos/EmailInfo.cs
+++ b/SN.Application/Dtos/EmailInfo.cs
@@ -7,6 +7,7 @@ namespace SN.Application.Dtos;
 public record EmailInfo(int Id, string Date, string From, string Subject, string PlainTextBody, string HtmlBody)
 {
     public List<FileAttachment> FileAttachments { get; init; } = new List<FileAttachment>();
+    public List<FileAttachment> RelatedFileAttachments { get; init; } = new List<FileAttachment>();
 
     public bool Validate()
     {

--- a/SN.Application/Interfaces/ISlackApiService.cs
+++ b/SN.Application/Interfaces/ISlackApiService.cs
@@ -1,7 +1,12 @@
-﻿namespace SN.Application.Interfaces;
+﻿using SN.Core.ValueObjects;
+
+namespace SN.Application.Interfaces;
 
 public interface ISlackApiService
 {
     Task<HttpResponseMessage> SendMessage(StringContent requestBody);
     Task<HttpResponseMessage> UploadFile(MultipartFormDataContent formData);
+    Task<HttpResponseMessage> GetUploadUrlAsync(string fileType, string filename, long filesize);
+    Task<HttpResponseMessage> UploadFileAsync(string uploadUrl, byte[] fileBytes);
+    Task<HttpResponseMessage> CompleteUploadAsync(string fileId, string filename, string messageThread);
 }

--- a/SN.Application/Interfaces/ISlackApiService.cs
+++ b/SN.Application/Interfaces/ISlackApiService.cs
@@ -8,5 +8,5 @@ public interface ISlackApiService
     Task<HttpResponseMessage> UploadFile(MultipartFormDataContent formData);
     Task<HttpResponseMessage> GetUploadUrlAsync(string fileType, string filename, long filesize);
     Task<HttpResponseMessage> UploadFileAsync(string uploadUrl, byte[] fileBytes);
-    Task<HttpResponseMessage> CompleteUploadAsync(string fileId, string filename, string messageThread);
+    Task<HttpResponseMessage> CompleteUploadAsync(Dictionary<string, string> files, string messageThread);
 }

--- a/SN.Application/Interfaces/ISlackApiService.cs
+++ b/SN.Application/Interfaces/ISlackApiService.cs
@@ -1,11 +1,8 @@
-﻿using SN.Core.ValueObjects;
-
-namespace SN.Application.Interfaces;
+﻿namespace SN.Application.Interfaces;
 
 public interface ISlackApiService
 {
     Task<HttpResponseMessage> SendMessage(StringContent requestBody);
-    Task<HttpResponseMessage> UploadFile(MultipartFormDataContent formData);
     Task<HttpResponseMessage> GetUploadUrlAsync(string fileType, string filename, long filesize);
     Task<HttpResponseMessage> UploadFileAsync(string uploadUrl, byte[] fileBytes);
     Task<HttpResponseMessage> CompleteUploadAsync(Dictionary<string, string> files, string messageThread);

--- a/SN.Application/Interfaces/ISlackBlockBuilder.cs
+++ b/SN.Application/Interfaces/ISlackBlockBuilder.cs
@@ -1,0 +1,17 @@
+﻿using SN.Application.Builders;
+
+namespace SN.Application.Interfaces;
+
+public interface ISlackBlockBuilder
+{
+    StringContent Build();
+    ISlackBlockBuilder FromSender(string sender);
+    ISlackBlockBuilder ToChannel(string channel);
+    ISlackBlockBuilder WithDivider();
+    ISlackBlockBuilder WithHeaderTitle(string header);
+    ISlackBlockBuilder WithMessageBody(string messageBody);
+    ISlackBlockBuilder WithRelatedFile(string fileName, string fileId);
+    ISlackBlockBuilder WithRelatedFiles(Dictionary<string, string> fileNames);
+    ISlackBlockBuilder WithSendDate(string date);
+    ISlackBlockBuilder WithSubject(string subject);
+}

--- a/SN.Application/Services/GmailInboxService.cs
+++ b/SN.Application/Services/GmailInboxService.cs
@@ -66,7 +66,7 @@ public class GmailInboxService : IGmailInboxService
 
         if (message != null)
         {
-            //await gmailApiService.ToggleMessageToRead(emailId); //TODO: uncomment this line
+            await gmailApiService.ToggleMessageToRead(emailId);
             var email = new EmailInfo(
                 counter,
                 message.Payload.Headers.Single(x => x.Name == "Date").Value,

--- a/SN.Application/Services/GmailInboxService.cs
+++ b/SN.Application/Services/GmailInboxService.cs
@@ -136,6 +136,13 @@ public class GmailInboxService : IGmailInboxService
                 email.FileAttachments.AddRange(await gmailPayloadService.GetAttachments(message.Id, gmailAttachmentData));
             }
 
+            var relatedAttachments = message.Payload.Parts
+                .SingleOrDefault(x => x.MimeType == "multipart/related")?
+                .Parts
+                .Where(x => x.MimeType != "multipart/alternative") ?? Enumerable.Empty<MessagePart>();
+
+            email.RelatedFileAttachments.AddRange(await gmailPayloadService.GetAttachments(message.Id, relatedAttachments));
+
             return email.Validate() ? email : null;
         }
 

--- a/SN.Application/Services/SlackService.cs
+++ b/SN.Application/Services/SlackService.cs
@@ -37,7 +37,7 @@ public class SlackService : ISlackService
             var messageThread = string.Empty;
 
             var blockBuilder = slackBlockBuilder
-                .WithDivider()
+                .WithHeaderTitle("Mail vidarebefodrat från orgrytetorp@gmail.com:")
                 .WithSendDate(message.Date)
                 .ToChannel(options.Destination)
                 .FromSender(message.From)

--- a/SN.Console/Program.cs
+++ b/SN.Console/Program.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using SN.Application.Builders;
 using SN.Application.Interfaces;
+using SN.Application.Services;
 using SN.ConsoleApp.Extensions;
 
 namespace MailService;
@@ -30,6 +32,8 @@ class Program
                 services.ConfigureOptionsFromAppsettings(configuration);
                 services.AddSingleton<IConfiguration>(configuration);
                 services.AddServices();
+                services.AddScoped<ISlackBlockBuilder, SlackBlockBuilder>();
+
             })
             .Build();
 

--- a/SN.Console/Program.cs
+++ b/SN.Console/Program.cs
@@ -36,22 +36,22 @@ class Program
 
         _messageForwarder = host.Services.GetRequiredService<IMessageForwarderService>();
         await _messageForwarder.Run();
-        //_timer = new Timer(DoWork, null, TimeSpan.Zero, TimeSpan.FromMinutes(30));
-        
-        //Console.WriteLine("Console application started.");
-        //while (true)
-        //{
-        //    Console.WriteLine("Press Enter to exit");
-        //    var input = Console.ReadLine();
-            
-        //    if (string.IsNullOrEmpty(input))
-        //    {
-        //        host.StopAsync()
-        //            .Wait();
-        //        return;
-        //    }
-        //    Console.Clear();
-        //}
+        _timer = new Timer(DoWork, null, TimeSpan.Zero, TimeSpan.FromMinutes(30));
+
+        Console.WriteLine("Console application started.");
+        while (true)
+        {
+            Console.WriteLine("Press Enter to exit");
+            var input = Console.ReadLine();
+
+            if (string.IsNullOrEmpty(input))
+            {
+                host.StopAsync()
+                    .Wait();
+                return;
+            }
+            Console.Clear();
+        }
     }
 
     public static string GetEnvironment

--- a/SN.Console/Program.cs
+++ b/SN.Console/Program.cs
@@ -35,7 +35,6 @@ class Program
 
 
         _messageForwarder = host.Services.GetRequiredService<IMessageForwarderService>();
-        await _messageForwarder.Run();
         _timer = new Timer(DoWork, null, TimeSpan.Zero, TimeSpan.FromMinutes(30));
 
         Console.WriteLine("Console application started.");

--- a/SN.Core/ValueObjects/SlackGetUploadUrlResponse.cs
+++ b/SN.Core/ValueObjects/SlackGetUploadUrlResponse.cs
@@ -1,0 +1,24 @@
+﻿using System.Text.Json.Serialization;
+using System.Text.Json;
+
+namespace SN.Core.ValueObjects;
+
+public record SlackGetUploadUrlResponse()
+{
+    [JsonPropertyName("ok")]
+    public bool Ok { get; set; }
+
+    [JsonPropertyName("error")]
+    public string Error { get; set; }
+
+    [JsonPropertyName("upload_url")]
+    public string UploadUrl { get; set; }
+
+    [JsonPropertyName("file_id")]
+    public string FileId { get; set; }
+
+    public static SlackGetUploadUrlResponse FromJson(string json)
+    {
+        return JsonSerializer.Deserialize<SlackGetUploadUrlResponse>(json);
+    }
+};

--- a/SN.Infrastructure/Services/Slack/SlackApiEndpoints.cs
+++ b/SN.Infrastructure/Services/Slack/SlackApiEndpoints.cs
@@ -3,7 +3,6 @@
 public static class SlackApiEndpoints
 {
     public const string PostMessage = "/api/chat.postMessage";
-    public const string UploadFile = "/api/files.upload";
     public const string GetUploadUrl = "/api/files.getUploadURLExternal";
     public const string CompleteUpload = "/api/files.completeUploadExternal?";
 }

--- a/SN.Infrastructure/Services/Slack/SlackApiEndpoints.cs
+++ b/SN.Infrastructure/Services/Slack/SlackApiEndpoints.cs
@@ -4,4 +4,6 @@ public static class SlackApiEndpoints
 {
     public const string PostMessage = "/api/chat.postMessage";
     public const string UploadFile = "/api/files.upload";
+    public const string GetUploadUrl = "/api/files.getUploadURLExternal";
+    public const string CompleteUpload = "/api/files.completeUploadExternal?";
 }

--- a/SN.Infrastructure/Services/Slack/SlackApiService.cs
+++ b/SN.Infrastructure/Services/Slack/SlackApiService.cs
@@ -26,14 +26,6 @@ public class SlackApiService : ISlackApiService
         return await client.PostAsync(SlackApiEndpoints.PostMessage, requestBody);
     }
 
-    public async Task<HttpResponseMessage> UploadFile(MultipartFormDataContent formData)
-    {
-        var client = httpClientFactory.CreateClient(nameof(SlackApiService));
-        client.DefaultRequestHeaders.Add("Authorization", $"Bearer {options.Token}");
-
-        return await client.PostAsync(SlackApiEndpoints.UploadFile, formData);
-    }
-
     public async Task<HttpResponseMessage> GetUploadUrlAsync(string fileType, string filename, long filesize)
     {
         var requestUrl = $"{SlackApiEndpoints.GetUploadUrl}" +

--- a/SN.Infrastructure/Services/Slack/SlackApiService.cs
+++ b/SN.Infrastructure/Services/Slack/SlackApiService.cs
@@ -47,20 +47,25 @@ public class SlackApiService : ISlackApiService
         return response;
     }
 
-    public async Task<HttpResponseMessage> CompleteUploadAsync(Dictionary<string,string> files, string messageThread)
+    public async Task<HttpResponseMessage> CompleteUploadAsync(Dictionary<string,string> files, string messageThread = null)
     {
         var jsonObject = new JObject(
-            new JProperty("channel_id", $"{options.Destination}"),
-            new JProperty("thread_ts", $"{messageThread}"),
-            new JProperty("initial_comment", files.Count > 1 ? "Bifogade filer" : "Bifogad fil"),
             new JProperty("files",
                 new JArray(files.Select(f =>
                 {
                     return new JObject(
-                        new JProperty("id", $"{f.Key}"), 
-                        new JProperty("title", $"{f.Value}"));
+                        new JProperty("id", $"{f.Value}"), 
+                        new JProperty("title", $"{f.Key}"));
                 }))
             ));
+
+        if (!string.IsNullOrWhiteSpace(messageThread))
+        {
+            jsonObject.Add(new JProperty("channel_id", $"{options.Destination}"));
+            jsonObject.Add(new JProperty("initial_comment", files.Count > 1 ? "Bifogade filer" : "Bifogad fil"));
+            jsonObject.Add(new JProperty("thread_ts", $"{messageThread}"));
+        }
+
         var requestBody = new StringContent(jsonObject.ToString(), Encoding.UTF8);
         requestBody.Headers.ContentType.MediaType = "application/json";
         

--- a/SN.Infrastructure/Services/Slack/SlackApiService.cs
+++ b/SN.Infrastructure/Services/Slack/SlackApiService.cs
@@ -1,7 +1,13 @@
 ﻿using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
 using SN.Application.Interfaces;
 using SN.Application.Options;
 using SN.Application.Services;
+using SN.Core.ValueObjects;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Channels;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace SN.Infrastructure.Services.Slack;
 
@@ -30,5 +36,54 @@ public class SlackApiService : ISlackApiService
         client.DefaultRequestHeaders.Add("Authorization", $"Bearer {options.Token}");
 
         return await client.PostAsync(SlackApiEndpoints.UploadFile, formData);
+    }
+
+    public async Task<HttpResponseMessage> GetUploadUrlAsync(string fileType, string filename, long filesize)
+    {
+        var requestUrl = $"{SlackApiEndpoints.GetUploadUrl}" +
+                         $"?filename={filename}&" +
+                         $"length={filesize}";
+        var client = httpClientFactory.CreateClient(nameof(SlackApiService));
+        client.DefaultRequestHeaders.Add("Authorization", $"Bearer {options.Token}");
+        var response = await client.GetAsync(requestUrl);
+               
+        return response;
+    }
+
+    public async Task<HttpResponseMessage> UploadFileAsync(string uploadUrl, byte[] fileBytes)
+    {
+        var client = httpClientFactory.CreateClient(nameof(SlackApiService));
+
+        using var content = new ByteArrayContent(fileBytes);
+
+        var response = await client.PostAsync(uploadUrl, content);
+
+        return response;
+    }
+
+    public async Task<HttpResponseMessage> CompleteUploadAsync(string fileId, string filename, string messageThread)
+    {
+        var jsonObject = new JObject(
+            new JProperty("channel_id", $"{options.Destination}"),
+            new JProperty("thread_ts", $"{messageThread}"),
+            new JProperty("files",
+                new JArray(
+                    new JObject(
+                        new JProperty("id",  $"{fileId}"),
+                        new JProperty("title",  $"{filename}")
+                    )
+                )
+            )
+        );
+
+        var requestBody = new StringContent(jsonObject.ToString(), Encoding.UTF8);
+        requestBody.Headers.ContentType.MediaType = "application/json";
+        
+        //TODO: fixa om till JSON enligt https://api.slack.com/methods/files.completeUploadExternal
+        var client = httpClientFactory.CreateClient(nameof(SlackApiService));
+        client.DefaultRequestHeaders.Add("Authorization", $"Bearer {options.Token}");
+        var response = await client.PostAsync(SlackApiEndpoints.CompleteUpload, requestBody);
+
+        return response;
     }
 }

--- a/SN.UnitTests/SN.Infrastructure/SlackApiServiceTests.cs
+++ b/SN.UnitTests/SN.Infrastructure/SlackApiServiceTests.cs
@@ -25,7 +25,7 @@ public class SlackApiServiceTests : BaseTests
         var SUT = CreateSUT(httpClientFactory);
 
         // Act
-        var response = await SUT.UploadFile(formData);
+        var response = await SUT.GetUploadUrlAsync(Fixture.Create<string>(), Fixture.Create<string>(), Fixture.Create<long>());
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -48,7 +48,7 @@ public class SlackApiServiceTests : BaseTests
         var SUT = CreateSUT(httpClientFactory);
 
         // Act
-        var response = await SUT.UploadFile(formData);
+        var response = await SUT.GetUploadUrlAsync(Fixture.Create<string>(), Fixture.Create<string>(), Fixture.Create<int>());
 
         // Assert
         Assert.True(capturedRequest.Headers.Contains("Authorization"));


### PR DESCRIPTION
## New Features
- Feature 1: Supports images in message body of email.
- Feature 2: Uses the block-kit feature of Slack to compose a Slack message.
- Feature 3: The file upload process uses the api methods files.getUploadURLExternal and files.completeUploadExternal instead of files.upload as it is deprecated as of May 8, 2024.


