### PR TITLE
Bugfixes

### DIFF
--- a/SN.Application/Builders/SlackBlockBuilder.cs
+++ b/SN.Application/Builders/SlackBlockBuilder.cs
@@ -16,10 +16,40 @@ public class SlackBlockBuilder : ISlackBlockBuilder
     private ContextBlock senderName = null;
     private ContextBlock senderEmail = null;
     private SectionBlock subject = null;
-    
+
     private string messageBody = string.Empty;
     private Dictionary<string,string> relatedFiles = new();
-    
+
+    public string CurrentSenderName 
+    { 
+        get
+        {
+            if (senderName is null ) return string.Empty;
+
+            var text = (senderName
+                .elements
+                .Single(e => e.GetType() == typeof(MarkdownBlock)) as MarkdownBlock)
+                .text;
+
+            return text;
+        }
+    }
+
+    public string CurrentSenderEmail
+    {
+        get
+        {
+            if (senderEmail is null) return string.Empty;
+
+            var text = (senderEmail
+                .elements
+                .Single(e => e.GetType() == typeof(MarkdownBlock)) as MarkdownBlock)
+                .text;
+
+            return text;
+        }
+    }
+
     public void Clear()
     {
         root = new Blocks();
@@ -62,11 +92,12 @@ public class SlackBlockBuilder : ISlackBlockBuilder
     public ISlackBlockBuilder FromSender(string sender)
     {
         var formattedText = FormatEmailLinkInFromText(sender);
-        var email = ExtractEmail(formattedText);
+        var email = ExtractEmail(formattedText).Trim();
         var name = formattedText
             .Replace(email, string.Empty)
             .Replace("\"", string.Empty)
-            .Replace("\\", string.Empty);
+            .Replace("\\", string.Empty)
+            .Trim();
 
         senderName = new ContextBlock(nameIconuri, $"*Från:* {name}");
         senderEmail = new ContextBlock(emailIconUri, $"*Email:* {email}");
@@ -195,6 +226,10 @@ public class SlackBlockBuilder : ISlackBlockBuilder
 
                 return replacedText;
             }
+        } 
+        else if (text.Contains('@'))
+        {
+            text = $"{text.Split('@')[0]} <mailto:{text}|{text}>";
         }
 
         return text;

--- a/SN.Application/Interfaces/IGmailPayloadService.cs
+++ b/SN.Application/Interfaces/IGmailPayloadService.cs
@@ -8,4 +8,5 @@ public interface IGmailPayloadService
     IEnumerable<MessagePart> GetAttachmentData(IList<MessagePart> parts);
     Task<List<FileAttachment>> GetAttachments(string messageId, IEnumerable<MessagePart> gmailAttachmentData);
     string GetText(MessagePart payload);
+    string GetTextFromHtml(MessagePart payload);
 }

--- a/SN.Application/SN.Application.csproj
+++ b/SN.Application/SN.Application.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Apis.Gmail.v1" Version="1.62.1.3217" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 

--- a/SN.Console/Program.cs
+++ b/SN.Console/Program.cs
@@ -12,7 +12,7 @@ class Program
     private static IMessageForwarderService _messageForwarder;
     private static Timer _timer;
     private static SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
-    
+    private static readonly string version = "1.0.001";
 
     static async Task Main(string[] args)
     {
@@ -24,6 +24,7 @@ class Program
                     ? "Development"
                     : "Production";
                 Console.WriteLine($"[{DateTime.Now.ToLocalTime()}] Environment set to {environment}");
+                Console.WriteLine($"[{DateTime.Now.ToLocalTime()}] Starting version {version} of application.");
 
                 var configuration = new ConfigurationBuilder()
                     .SetBasePath(Directory.GetCurrentDirectory())

--- a/SN.UnitTests/SN.Application/SlackBuilderTests.cs
+++ b/SN.UnitTests/SN.Application/SlackBuilderTests.cs
@@ -1,0 +1,69 @@
+﻿using FluentAssertions;
+using SN.Application.Builders;
+
+namespace SN.UnitTests.SN.Application;
+
+public class SlackBuilderTests : BaseTests
+{
+    [Fact]
+    public void FromSender_WhenSenderTextOnlyContainsEmailAddress_NameIsExtractedFromEmail()
+    {
+        // Assign
+        var input = "my.name@email.com";
+        var SUT = new SlackBlockBuilder();
+
+        // Act
+        var result = SUT.FromSender(input).As<SlackBlockBuilder>();
+
+        // Assert
+        result.CurrentSenderName
+            .Should()
+            .Be("*Från:* my.name");
+    }
+
+    [Fact]
+    public void FromSender_WhenSenderTextOnlyContainsEmailAddress_EmailIsCorrectlyFormatted()
+    {
+        // Assign
+        var input = "my.name@email.com";
+        var SUT = new SlackBlockBuilder();
+
+        var result = SUT.FromSender(input).As<SlackBlockBuilder>();
+
+        // Assert
+        result.CurrentSenderEmail
+            .Should()
+            .Be("*Email:* <mailto:my.name@email.com|my.name@email.com>");
+    }
+
+    [Fact]
+    public void FromSender_WhenSenderTextContainsNameAndEmailAddress_NameIsExtractedFromEmail()
+    {
+        // Assign
+        var input = "\"my name\" <my.name@email.com>";
+        var SUT = new SlackBlockBuilder();
+
+        // Act
+        var result = SUT.FromSender(input).As<SlackBlockBuilder>();
+
+        // Assert
+        result.CurrentSenderName
+            .Should()
+            .Be("*Från:* my name");
+    }
+
+    [Fact]
+    public void FromSender_WhenSenderTextContainsNameAndEmailAddress_EmailIsCorrectlyFormatted()
+    {
+        // Assign
+        var input = "\"my name\" <my.name@email.com>";
+        var SUT = new SlackBlockBuilder();
+
+        var result = SUT.FromSender(input).As<SlackBlockBuilder>();
+
+        // Assert
+        result.CurrentSenderEmail
+            .Should()
+            .Be("*Email:* <mailto:my.name@email.com|my.name@email.com>");
+    }
+}


### PR DESCRIPTION
- Name omitted in email address tag cause crash (i.e. <karl.karlsson@mail.com> instead of karl karlsson <karl.karlsson@mail.com)
- Crashes if email without attachment only has html-text