### PR TITLE
Remove fetching the whole mail thread

### DIFF
--- a/SN.Application/Services/GmailInboxService.cs
+++ b/SN.Application/Services/GmailInboxService.cs
@@ -23,37 +23,14 @@ public class GmailInboxService : IGmailInboxService
     public async Task<List<EmailInfo>> CheckForEmails()
     {
         List<Message> emailListResponse = await gmailApiService.GetListOfMessages();
-        IEnumerable<IGrouping<string, Message>> threads = emailListResponse
-            .GroupBy(x => x.ThreadId); ;
-
         int counter = 1;
         var emails = new List<EmailInfo>();
-        foreach (var thread in threads)
+        foreach (var item in emailListResponse)
         {
-            var threadMaster = thread
-                .Where(item => item.Id == item.ThreadId)
-                .ToList();
-            var threadChilds = thread
-                .Except(threadMaster)
-                .ToList();
-
-            foreach (var item in threadMaster)
-            {
-                var email = await GetEmail(item.Id, counter++);
-
-                if (email is null) continue;
-
-                emails.Add(email);
-            }
-
-            foreach (var item in threadChilds)
-            {
-                var email = await GetEmail(item.Id, counter++);
-
-                if (email is null) continue;
-
-                emails.Add(email);
-            }
+            var email = await GetEmail(item.Id, counter++);
+            if (email is null) continue;
+            
+            emails.Add(email);
         }
 
         return emails;

--- a/SN.Console/Program.cs
+++ b/SN.Console/Program.cs
@@ -12,7 +12,7 @@ class Program
     private static IMessageForwarderService _messageForwarder;
     private static Timer _timer;
     private static SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
-    private static readonly string version = "1.0.1";
+    private static readonly string version = "1.0.2";
 
     static async Task Main(string[] args)
     {


### PR DESCRIPTION
 1. Fix forwarded message in same message thread generates incorrect output to channel.
    The whole message thread is sent to channel instead of just the message
 