### PR TITLE
Run headless without browser authentication using Imap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -486,3 +486,5 @@ config.zip
 .aider.conf.yml
 .aider.input.history
 .aider.model.settings.yml
+SN.Console/GoogleImapSecretsDevelopment.json
+SN.Console/GoogleImapSecretsProduction.json

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Forward Gmail messages to a Slack channel
 
 #### Setup Google application password (preferred method)
 1. Log in to your google account.
-2. Go to https://myaccount.google.com/apppasswords  
+2. Go to https://myaccount.google.com/apppasswords, if this doesn't work then enable two-step verification.  
 3. Create an application password. Save the password.
 4. Create a json file called GoogleImapSecretsDevelopment.json
 5. Add the following structure:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,21 @@ Forward Gmail messages to a Slack channel
 
 ### Installation
 
-#### Setup Google Console
+#### Setup Google application password (preferred method)
+1. Log in to your google account.
+2. Go to https://myaccount.google.com/apppasswords  
+3. Create an application password. Save the password.
+4. Create a json file called GoogleImapSecretsDevelopment.json
+5. Add the following structure:
+```JSON
+{
+	"email": "<your email>",
+	"password": "<your google application password>"
+}
+```
+6. Copy the file to GoogleImapSecretsProduction.json, change email and password if needed.
+
+#### Setup Google Console (fallback if application password shuts down)
 Prerequisites: Gmail account + access to Google console
 1. Log in to Google Console at https://console.cloud.google.com/
 2. Create a new project
@@ -37,6 +51,11 @@ Prerequisites: Slack account
 4. Save the **SlackSecretsDevelopment.json** file to the _SN.Console_ folder. Make a copy named **SlackSecretsProduction.json** for configuration of production settings.
 5. Choose to _Install to Workspace_ to enable the app. A message will pop up in the channel that a new integration has been created.
 6. Important! Invite your bot to your channel.
+
+#### Choose method of fetching emails
+1. Open appsettings.json 
+2. Set the following value to run the application headless:   "GmailStrategy" : "Headless"
+3. Set the following value to run the application with Oauth2, authenticating via the browser. You will need to be logged in to your gmail account. "GmailStrategy" : "BrowserAuthentication". Can be used as fallback if Google removes application password authentication.
 
 #### Setup done
 Double-check that the secrets files are in the SN.Console project.

--- a/SN.Application/Clients/ImapConnectionClient.cs
+++ b/SN.Application/Clients/ImapConnectionClient.cs
@@ -1,0 +1,27 @@
+﻿using MailKit;
+using MailKit.Net.Imap;
+using MailKit.Security;
+using SN.Application.Dtos;
+
+namespace SN.Application.Services;
+
+public partial class GmailImapService
+{
+    public class ImapConnectionClient : IImapConnectionClient
+    {
+        public async Task<IImapClient> ConnectAsync(GoogleApplicationPasswordSecrets secrets)
+        {
+            var client = new ImapClient();
+            await client.ConnectAsync("imap.gmail.com", 993, SecureSocketOptions.SslOnConnect);
+            await client.AuthenticateAsync(secrets.Email, secrets.Password);
+            await client.Inbox.OpenAsync(FolderAccess.ReadWrite);
+
+            return client;
+        }
+
+        public async Task DisconnectAsync(IImapClient client)
+        {
+            await client.DisconnectAsync(true);
+        }
+    }
+}

--- a/SN.Application/Dtos/FileAttachment.cs
+++ b/SN.Application/Dtos/FileAttachment.cs
@@ -1,6 +1,6 @@
 ﻿namespace SN.Application.Dtos;
 
-public record FileAttachment(string FileName, string fileType, string Description, string Data)
+public record FileAttachment(string FileName, string FileType, string Description, string Data)
 {
     private const string FileTypeIsNotSupported = "Unsupported filetype";
 
@@ -14,7 +14,7 @@ public record FileAttachment(string FileName, string fileType, string Descriptio
     public bool Validate()
     {
         if (string.IsNullOrWhiteSpace(FileName)) return false;
-        if (string.IsNullOrWhiteSpace(fileType) || fileType == FileTypeIsNotSupported) return false;
+        if (string.IsNullOrWhiteSpace(FileType) || FileType == FileTypeIsNotSupported) return false;
         if (string.IsNullOrWhiteSpace(Data)) return false;
 
         return true;

--- a/SN.Application/Dtos/GoogleApplicationPasswordSecrets.cs
+++ b/SN.Application/Dtos/GoogleApplicationPasswordSecrets.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SN.Application.Dtos;
+
+public class GoogleApplicationPasswordSecrets
+{
+    public string Email { get; init; }
+    public string Password { get; init; }
+}

--- a/SN.Application/Extensions/StringConversionExtensions.cs
+++ b/SN.Application/Extensions/StringConversionExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace SN.Application.Extensions;
+
+public static class StringConversionExtensions 
+{
+    public static int ToIntOrDefault(this string value, int defaultValue = 0)
+    {
+        return int.TryParse(value, out var result) ? result : defaultValue;
+    }
+
+}

--- a/SN.Application/Interfaces/IGmailImapService.cs
+++ b/SN.Application/Interfaces/IGmailImapService.cs
@@ -1,0 +1,8 @@
+﻿using MimeKit;
+
+namespace SN.Application.Interfaces;
+
+public interface IGmailImapService
+{
+    Task<List<MimeMessage>> DownloadEmails();
+}

--- a/SN.Application/Interfaces/IGmailInboxService.cs
+++ b/SN.Application/Interfaces/IGmailInboxService.cs
@@ -4,5 +4,7 @@ namespace SN.Application.Interfaces;
 
 public interface IGmailInboxService
 {
+    string strategy { get; }
+
     Task<List<EmailInfo>> CheckForEmails();
 }

--- a/SN.Application/Interfaces/IImapConnectionClient.cs
+++ b/SN.Application/Interfaces/IImapConnectionClient.cs
@@ -1,0 +1,13 @@
+﻿using MailKit.Net.Imap;
+using SN.Application.Dtos;
+
+namespace SN.Application.Services;
+
+public partial class GmailImapService
+{
+    public interface IImapConnectionClient
+    {
+        Task<IImapClient> ConnectAsync(GoogleApplicationPasswordSecrets secrets);
+        Task DisconnectAsync(IImapClient client);
+    }
+}

--- a/SN.Application/SN.Application.csproj
+++ b/SN.Application/SN.Application.csproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <PackageReference Include="Google.Apis.Gmail.v1" Version="1.62.1.3217" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 

--- a/SN.Application/Services/GmailApplicationPasswordService.cs
+++ b/SN.Application/Services/GmailApplicationPasswordService.cs
@@ -1,4 +1,7 @@
-﻿using SN.Application.Dtos;
+﻿using Microsoft.Extensions.Logging;
+using MimeKit;
+using SN.Application.Dtos;
+using SN.Application.Extensions;
 using SN.Application.Interfaces;
 
 namespace SN.Application.Services;
@@ -8,16 +11,66 @@ public class GmailApplicationPasswordService : IGmailInboxService
     public string strategy => "Headless";
 
     private readonly IGmailImapService gmailImapService;
+    private readonly ILogger<GmailApplicationPasswordService> logger;
+    private readonly List<EmailInfo> emailInfos = new List<EmailInfo>();
 
-    public GmailApplicationPasswordService(IGmailImapService gmailImapService)
+    public GmailApplicationPasswordService(IGmailImapService gmailImapService, ILogger<GmailApplicationPasswordService> logger)
     {
         this.gmailImapService = gmailImapService;
+        this.logger = logger;
     }
 
-    public Task<List<EmailInfo>> CheckForEmails()
+    public async Task<List<EmailInfo>> CheckForEmails()
     {
-        var messages = gmailImapService.DownloadEmails();
+        var messages = await gmailImapService.DownloadEmails();
 
-        throw new NotImplementedException();
+        foreach (var email in messages)
+        {
+            var id = email.MessageId.ToIntOrDefault();
+            var dateSent = GetLocalTimeZone(email);
+            var from = email.From.Mailboxes.FirstOrDefault()?.ToString() ?? "Okänd avsändare";
+            var subject = email.Subject ?? string.Empty;
+            var plaintextBody = email.TextBody ?? string.Empty;
+            var htmlBody = email.HtmlBody ?? string.Empty;
+            var fileAttachments = GetAttachments(email);
+            var emailInfo = new EmailInfo(id, dateSent, from, subject, plaintextBody, htmlBody);
+            emailInfo.FileAttachments.AddRange(fileAttachments);
+            if (!emailInfo.Validate())
+            {
+                logger.LogInformation("Email with ID {EmailId} failed validation and will be skipped.", emailInfo.Id);
+                continue;
+            }
+            emailInfos.Add(emailInfo);
+        }
+
+        return emailInfos;
+    }
+
+    private static string GetLocalTimeZone(MimeMessage email)
+    {
+        return TimeZoneInfo
+            .ConvertTimeBySystemTimeZoneId(email.Date.UtcDateTime, "Europe/Stockholm")
+            .ToString("yyyy-MM-dd HH:mm:ss");
+    }
+
+    private static List<FileAttachment> GetAttachments(MimeMessage email)
+    {
+        return email.Attachments
+            .OfType<MimePart>()
+            .Select(part =>
+            {
+                using var stream = new MemoryStream();
+                part.Content.DecodeTo(stream);
+                var data = Convert.ToBase64String(stream.ToArray());
+
+                return new FileAttachment(
+                    FileName: part.FileName ?? string.Empty,
+                    FileType: part.ContentType.MimeType ?? string.Empty,
+                    Description: string.Empty,
+                    Data: data
+                );
+            })
+            .Where(a => a.Validate())
+            .ToList();
     }
 }

--- a/SN.Application/Services/GmailApplicationPasswordService.cs
+++ b/SN.Application/Services/GmailApplicationPasswordService.cs
@@ -1,0 +1,23 @@
+﻿using SN.Application.Dtos;
+using SN.Application.Interfaces;
+
+namespace SN.Application.Services;
+
+public class GmailApplicationPasswordService : IGmailInboxService
+{
+    public string strategy => "Headless";
+
+    private readonly IGmailImapService gmailImapService;
+
+    public GmailApplicationPasswordService(IGmailImapService gmailImapService)
+    {
+        this.gmailImapService = gmailImapService;
+    }
+
+    public Task<List<EmailInfo>> CheckForEmails()
+    {
+        var messages = gmailImapService.DownloadEmails();
+
+        throw new NotImplementedException();
+    }
+}

--- a/SN.Application/Services/GmailImapService.cs
+++ b/SN.Application/Services/GmailImapService.cs
@@ -1,24 +1,40 @@
-﻿using MailKit;
+﻿using Google.Apis.Auth.OAuth2;
+using MailKit;
 using MailKit.Net.Imap;
 using MailKit.Search;
 using MailKit.Security;
+using Microsoft.Extensions.Configuration;
 using MimeKit;
+using Newtonsoft.Json;
+using SN.Application.Dtos;
 using SN.Application.Interfaces;
 
 namespace SN.Application.Services;
 
 public class GmailImapService : IGmailImapService
 {
-    private List<MimeMessage> emails { get; set; } = new List<MimeMessage>();
+    private readonly List<MimeMessage> emails = new List<MimeMessage>();
+    private readonly string googleCredentialsFilename;
+    private readonly string AppsettingsKey = "Appsettings:GoogleImapCredentialsFilename";
+    private readonly IIOService iOService;
+
+    public GmailImapService(IIOService iOService, IConfiguration configuration)
+    {
+        googleCredentialsFilename = configuration.GetSection(AppsettingsKey).Value;
+        this.iOService = iOService;
+    }
 
     public async Task<List<MimeMessage>> DownloadEmails()
-    {  
+    {
+        var credentials = iOService.ReadFileFromDisk(Directory.GetCurrentDirectory(), googleCredentialsFilename);
+        var secrets = JsonConvert.DeserializeObject<GoogleApplicationPasswordSecrets>(credentials);
+
         using var client = new ImapClient();
         await client.ConnectAsync("imap.gmail.com", 993, SecureSocketOptions.SslOnConnect);
-        await client.AuthenticateAsync("orgrytetorp@gmail.com", "ijmrpzudepmrldek");// <----- TODO: Move to configuration
+        await client.AuthenticateAsync(secrets.Email, secrets.Password);
         await client.Inbox.OpenAsync(FolderAccess.ReadWrite);
+        
         var uids = await client.Inbox.SearchAsync(SearchQuery.NotSeen);
-
         foreach (var uid in uids)
         {
             emails.Add(await client.Inbox.GetMessageAsync(uid));

--- a/SN.Application/Services/GmailImapService.cs
+++ b/SN.Application/Services/GmailImapService.cs
@@ -1,0 +1,32 @@
+﻿using MailKit;
+using MailKit.Net.Imap;
+using MailKit.Search;
+using MailKit.Security;
+using MimeKit;
+using SN.Application.Interfaces;
+
+namespace SN.Application.Services;
+
+public class GmailImapService : IGmailImapService
+{
+    private List<MimeMessage> emails { get; set; } = new List<MimeMessage>();
+
+    public async Task<List<MimeMessage>> DownloadEmails()
+    {  
+        using var client = new ImapClient();
+        await client.ConnectAsync("imap.gmail.com", 993, SecureSocketOptions.SslOnConnect);
+        await client.AuthenticateAsync("orgrytetorp@gmail.com", "ijmrpzudepmrldek");// <----- TODO: Move to configuration
+        await client.Inbox.OpenAsync(FolderAccess.ReadWrite);
+        var uids = await client.Inbox.SearchAsync(SearchQuery.NotSeen);
+
+        foreach (var uid in uids)
+        {
+            emails.Add(await client.Inbox.GetMessageAsync(uid));
+            await client.Inbox.SetFlagsAsync(uid, MessageFlags.Seen, true);
+        }
+
+        await client.DisconnectAsync(true);
+
+        return emails;
+    }
+}

--- a/SN.Application/Services/GmailImapService.cs
+++ b/SN.Application/Services/GmailImapService.cs
@@ -1,8 +1,6 @@
-﻿using Google.Apis.Auth.OAuth2;
-using MailKit;
+﻿using MailKit;
 using MailKit.Net.Imap;
 using MailKit.Search;
-using MailKit.Security;
 using Microsoft.Extensions.Configuration;
 using MimeKit;
 using Newtonsoft.Json;
@@ -11,29 +9,27 @@ using SN.Application.Interfaces;
 
 namespace SN.Application.Services;
 
-public class GmailImapService : IGmailImapService
+public partial class GmailImapService : IGmailImapService
 {
     private readonly List<MimeMessage> emails = new List<MimeMessage>();
     private readonly string googleCredentialsFilename;
     private readonly string AppsettingsKey = "Appsettings:GoogleImapCredentialsFilename";
     private readonly IIOService iOService;
+    private readonly IImapConnectionClient imapConnectionClient;
 
-    public GmailImapService(IIOService iOService, IConfiguration configuration)
+    public GmailImapService(IIOService iOService, IConfiguration configuration, IImapConnectionClient imapConnectionClient)
     {
         googleCredentialsFilename = configuration.GetSection(AppsettingsKey).Value;
         this.iOService = iOService;
+        this.imapConnectionClient = imapConnectionClient;
     }
 
     public async Task<List<MimeMessage>> DownloadEmails()
     {
         var credentials = iOService.ReadFileFromDisk(Directory.GetCurrentDirectory(), googleCredentialsFilename);
         var secrets = JsonConvert.DeserializeObject<GoogleApplicationPasswordSecrets>(credentials);
+        using IImapClient client = await imapConnectionClient.ConnectAsync(secrets);
 
-        using var client = new ImapClient();
-        await client.ConnectAsync("imap.gmail.com", 993, SecureSocketOptions.SslOnConnect);
-        await client.AuthenticateAsync(secrets.Email, secrets.Password);
-        await client.Inbox.OpenAsync(FolderAccess.ReadWrite);
-        
         var uids = await client.Inbox.SearchAsync(SearchQuery.NotSeen);
         foreach (var uid in uids)
         {
@@ -41,7 +37,7 @@ public class GmailImapService : IGmailImapService
             await client.Inbox.SetFlagsAsync(uid, MessageFlags.Seen, true);
         }
 
-        await client.DisconnectAsync(true);
+        await imapConnectionClient.DisconnectAsync(client);
 
         return emails;
     }

--- a/SN.Application/Services/GmailOauth2Service.cs
+++ b/SN.Application/Services/GmailOauth2Service.cs
@@ -5,13 +5,15 @@ using SN.Core.ValueObjects;
 
 namespace SN.Application.Services;
 
-public class GmailInboxService : IGmailInboxService
+public class GmailOauth2Service : IGmailInboxService
 {
+    public string strategy => "BrowserAuthentication";
+
     private readonly IGmailApiService gmailApiService;
     private readonly IGmailPayloadService gmailPayloadService;
     private readonly IMessageTypeService messageTypeService;
 
-    public GmailInboxService(IGmailApiService gmailApiService,
+    public GmailOauth2Service(IGmailApiService gmailApiService,
         IGmailPayloadService gmailPayloadService,
         IMessageTypeService messageTypeService)
     {

--- a/SN.Application/Services/MessageForwarderService.cs
+++ b/SN.Application/Services/MessageForwarderService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using SN.Application.Dtos;
 using SN.Application.Interfaces;
 using System.Text.RegularExpressions;
@@ -7,24 +8,33 @@ namespace SN.Application.Services;
 
 public class MessageForwarderService : IMessageForwarderService
 {
-    private readonly IGmailInboxService gmailInboxService;
+    private readonly Dictionary<string, IGmailInboxService> strategies;
     private readonly ISlackService slackService;
     private readonly ILogger<IMessageForwarderService> logger;
+    private readonly string strategy;
 
-    public MessageForwarderService(
-        IGmailInboxService gmailInboxService, 
+    public MessageForwarderService(IConfiguration configuration,
+        IEnumerable<IGmailInboxService> gmailInboxServices, 
         ISlackService slackService,
         ILogger<IMessageForwarderService> logger)
     {
-        this.gmailInboxService = gmailInboxService;
+        strategies = gmailInboxServices.ToDictionary(x => x.strategy, x => x);
+        strategy = configuration["GmailStrategy"];
         this.slackService = slackService;
         this.logger = logger;
     }
 
     public async Task Run()
     {
-        var emails = await gmailInboxService.CheckForEmails();
+        var gmailService = strategies.GetValueOrDefault(strategy);
+        if (gmailService is null) 
+        {
+            logger.LogWarning($"---> Strategy '{strategy}' not found.");
 
+            return;
+        }
+        
+        var emails = await gmailService.CheckForEmails();
         if (!emails.Any())
         {
             logger.LogInformation("---> No new emails found.");

--- a/SN.Application/Services/SlackService.cs
+++ b/SN.Application/Services/SlackService.cs
@@ -176,7 +176,7 @@ public class SlackService : ISlackService
         {
             try
             {
-                var getUploadUrlResponse = await slackApiService.GetUploadUrlAsync(item.fileType, item.FileName, item.ToByteArray().Length);
+                var getUploadUrlResponse = await slackApiService.GetUploadUrlAsync(item.FileType, item.FileName, item.ToByteArray().Length);
                 var getUploadUrlResponseContent = await getUploadUrlResponse.Content.ReadAsStringAsync();
                 var slackGetUploadUrlResponse = SlackGetUploadUrlResponse.FromJson(getUploadUrlResponseContent);
                 if (!getUploadUrlResponse.IsSuccessStatusCode || !slackGetUploadUrlResponse.Ok)

--- a/SN.Console/Extensions/ServiceCollectionExtensions.cs
+++ b/SN.Console/Extensions/ServiceCollectionExtensions.cs
@@ -55,5 +55,6 @@ public static class ServiceCollectionExtensions
         serviceCollection.AddScoped<IMessageTypeService, MessageTypeService>();
         serviceCollection.AddTransient<ISlackService, SlackService>();
         serviceCollection.AddTransient<ISlackApiService, SlackApiService>();
+        serviceCollection.AddTransient<IGmailImapService, GmailImapService>();
     }
 }

--- a/SN.Console/Extensions/ServiceCollectionExtensions.cs
+++ b/SN.Console/Extensions/ServiceCollectionExtensions.cs
@@ -45,7 +45,8 @@ public static class ServiceCollectionExtensions
 
     public static void AddServices(this  IServiceCollection serviceCollection)
     {
-        serviceCollection.AddScoped<IGmailInboxService, GmailInboxService>();
+        serviceCollection.AddScoped<IGmailInboxService, GmailOauth2Service>();
+        serviceCollection.AddScoped<IGmailInboxService, GmailApplicationPasswordService>();
         serviceCollection.AddScoped<IMessageForwarderService, MessageForwarderService>();
         serviceCollection.AddScoped<IGmailApiService, GmailApiService>();
         serviceCollection.AddScoped<IGmailPayloadService, GmailPayloadService>();

--- a/SN.Console/Program.cs
+++ b/SN.Console/Program.cs
@@ -13,7 +13,7 @@ namespace SN.ConsoleApp;
 
 class Program
 {
-    private static readonly string version = "1.1.0";
+    private static readonly string version = "1.2.0";
 
     static async Task Main(string[] args)
     {

--- a/SN.Console/Program.cs
+++ b/SN.Console/Program.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using MailKit.Net.Imap;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -6,6 +7,7 @@ using SN.Application.Builders;
 using SN.Application.Interfaces;
 using SN.ConsoleApp.Extensions;
 using SN.ConsoleApp.Services;
+using static SN.Application.Services.GmailImapService;
 
 namespace SN.ConsoleApp;
 
@@ -45,6 +47,7 @@ class Program
                 services.AddSingleton<IConfiguration>(configuration);
                 services.AddServices();
                 services.AddScoped<ISlackBlockBuilder, SlackBlockBuilder>();
+                services.AddTransient<IImapConnectionClient, ImapConnectionClient>();
                 services.AddHostedService<MessageForwarderHostedService>();
             })
             .Build();

--- a/SN.Console/SN.ConsoleApp.csproj
+++ b/SN.Console/SN.ConsoleApp.csproj
@@ -29,6 +29,12 @@
     <None Update="googleCredentials.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="GoogleImapSecretsDevelopment.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GoogleImapSecretsProduction.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="GoogleSecretsDevelopment.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/SN.Console/appsettings.Development.json
+++ b/SN.Console/appsettings.Development.json
@@ -1,6 +1,7 @@
 {
   "Appsettings": {
     "GoogleCredentialsOAuthFilename": "GoogleSecretsDevelopment.json",
-    "SlackCredentialsFilename": "SlackSecretsDevelopment.json"
+    "SlackCredentialsFilename": "SlackSecretsDevelopment.json",
+    "GoogleImapCredentialsFilename": "GoogleImapSecretsDevelopment.json"
   }
 }

--- a/SN.Console/appsettings.json
+++ b/SN.Console/appsettings.json
@@ -7,5 +7,6 @@
   "Appsettings": {
     "GmailBaseUri": "https://gmail.googleapis.com",
     "SlackBaseUri": "https://slack.com"
-  }
+  },
+  "GmailStrategy" : "Headless"
 }

--- a/SN.Console/appsettings.production.json
+++ b/SN.Console/appsettings.production.json
@@ -1,6 +1,7 @@
 {
   "Appsettings": {
     "GoogleCredentialsOAuthFilename": "GoogleSecretsProduction.json",
-    "SlackCredentialsFilename": "SlackSecretsProduction.json"
+    "SlackCredentialsFilename": "SlackSecretsProduction.json",
+    "GoogleImapCredentialsFilename": "GoogleImapSecretsProduction.json"
   }
 }

--- a/SN.Infrastructure/Services/Gmail/GmailApiService.cs
+++ b/SN.Infrastructure/Services/Gmail/GmailApiService.cs
@@ -47,7 +47,6 @@ public class GmailApiService : IGmailApiService
     public async Task<Message> DownloadEmail(string emailId)
     {
         logger.LogInformation($"---> Fetching gmail messages.");
-        Console.WriteLine($"[{DateTime.Now.ToLocalTime()}] Fetching gmail messages.");
         var emailRequest = gmailService.Users.Messages.Get(GmailServiceFactory.AuthenticatedUser, emailId);
         var message = await emailRequest.ExecuteAsync();
         logger.LogInformation($"---> Message received.");

--- a/SN.UnitTests/BaseTests.cs
+++ b/SN.UnitTests/BaseTests.cs
@@ -1,7 +1,32 @@
-﻿namespace SN.UnitTests;
+﻿using MimeKit;
+using System.Text;
+
+namespace SN.UnitTests;
 
 public abstract class BaseTests : TestFixture
 {
+
+    protected static MimeMessage MockEmail(string id = "1")
+    {
+        var message = new MimeMessage();
+        message.MessageId = id;
+        message.Date = DateTimeOffset.Now;
+        message.From.Add(new MailboxAddress("Martin Norén", "martinnoren@mymail.com"));
+        message.Subject = "Any subject";
+
+        var builder = new BodyBuilder
+        {
+            TextBody = "Hello world",
+            HtmlBody = "<p>Hello world</p>"
+        };
+
+        var attachmentBytes = Encoding.UTF8.GetBytes("fake pdf content");
+        builder.Attachments.Add("document.pdf", attachmentBytes, ContentType.Parse("application/pdf"));
+        message.Body = builder.ToMessageBody();
+
+        return message;
+    }
+
     protected string CredentialsJson = @"
     {
       ""web"": {

--- a/SN.UnitTests/SN.Application/GmailApplicationPasswordServiceTests.cs
+++ b/SN.UnitTests/SN.Application/GmailApplicationPasswordServiceTests.cs
@@ -1,0 +1,223 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MimeKit;
+using NSubstitute;
+using SN.Application.Dtos;
+using SN.Application.Extensions;
+using SN.Application.Interfaces;
+using SN.Application.Services;
+using System.Text;
+
+namespace SN.UnitTests.SN.Application;
+
+public class GmailApplicationPasswordServiceTests : BaseTests
+{
+    [Fact]
+    public void StrategyProperty_WhenCalled_ReturnsCorrectValue()
+    {
+        // Assign
+        var imapService = Substitute.For<IGmailImapService>();
+        var SUT = new GmailApplicationPasswordService(imapService, NullLogger<GmailApplicationPasswordService>.Instance);
+
+        // Act & Assert
+        SUT.strategy.Should().Be("Headless");
+    }
+
+    [Fact]
+    public async Task WhenCheckingForEmail_AndEmailExists_MethodReturnsCorrectValues()
+    {
+        // Assign
+        var imapService = Substitute.For<IGmailImapService>();
+        MimeMessage email = MockEmail();
+        imapService.DownloadEmails().Returns(new List<MimeMessage> { email });
+        var expectedObject = ExtractDataFromEmail(email);
+
+        var SUT = new GmailApplicationPasswordService(imapService, NullLogger<GmailApplicationPasswordService>.Instance);
+
+        // Act
+        var result = (await SUT.CheckForEmails()).Single();
+
+        // Assert
+        result.Id.Should().Be(expectedObject.Id);
+        result.Date.Should().Be(expectedObject.Date);
+        result.From.Should().Be(expectedObject.From);
+        result.Subject.Should().Be(expectedObject.Subject);
+        result.HtmlBody.Should().Be(expectedObject.HtmlBody);
+        result.PlainTextBody.Should().Be(expectedObject.PlainTextBody);
+        
+        result.FileAttachments
+            .Single().FileName
+            .Should()
+            .Be(expectedObject.FileAttachments.Single().FileName);
+
+        result.FileAttachments
+            .Single().Data
+            .Should()
+            .Be(expectedObject.FileAttachments.Single().Data);
+
+        result.FileAttachments
+            .Single().FileType
+            .Should()
+            .Be(expectedObject.FileAttachments.Single().FileType);
+
+        result.FileAttachments
+            .Single().Description
+            .Should()
+            .Be(expectedObject.FileAttachments.Single().Description);
+    }
+
+    [Fact]
+    public async Task WhenValidatingEmail_AndIdIsInvalid_EmailIsIgnoredAndEmptyListIsReturned()
+    {
+        // Assign
+        var imapService = Substitute.For<IGmailImapService>();
+        MimeMessage email = MockEmail(id: "-1");
+        imapService.DownloadEmails().Returns(new List<MimeMessage> { email });
+        var expectedObject = ExtractDataFromEmail(email);
+
+        var SUT = new GmailApplicationPasswordService(imapService, NullLogger<GmailApplicationPasswordService>.Instance);
+
+        // Act
+        var result = await SUT.CheckForEmails();
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenValidatingEmail_AndEmailIsInvalid_LoggingIsPerformed()
+    {
+        // Assign
+        var imapService = Substitute.For<IGmailImapService>();
+        MimeMessage email = MockEmail(id: "-1");
+        imapService.DownloadEmails().Returns(new List<MimeMessage> { email });
+        var expectedObject = ExtractDataFromEmail(email);
+        var logger = Substitute.For<ILogger<GmailApplicationPasswordService>>();
+
+        var SUT = new GmailApplicationPasswordService(imapService, logger);
+
+        // Act
+        var result = await SUT.CheckForEmails();
+
+        // Assert
+        AssertLogReceived(1, LogLevel.Information, logger, $"Email with ID {email.MessageId} failed validation and will be skipped.");
+    }
+
+    [Fact]
+    public async Task WhenEmailReceived_AndFromSenderIsMissing_ValueOkändAvsändareIsSetByDefault()
+    {
+        // Assign
+        var imapService = Substitute.For<IGmailImapService>();
+        MimeMessage email = MockEmail();
+        email.From.Clear();
+        imapService.DownloadEmails().Returns(new List<MimeMessage> { email });
+        var expectedObject = ExtractDataFromEmail(email);
+
+        var SUT = new GmailApplicationPasswordService(imapService, NullLogger<GmailApplicationPasswordService>.Instance);
+
+        // Act
+        var result = await SUT.CheckForEmails();
+
+        // Assert
+        result.Single().From.Should().Be("Okänd avsändare");
+    }
+
+    private void AssertLogReceived(
+        int amount,
+        LogLevel logLevel,
+        ILogger<GmailApplicationPasswordService> logger,
+        string expectedMessageContains = null)
+    {
+        var matchingCalls = logger.ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name == "Log")
+            .Where(call =>
+            {
+                var args = call.GetArguments();
+                return args[0] is LogLevel level && level == logLevel;
+            })
+            .ToList();
+
+        matchingCalls.Should().HaveCount(amount);
+
+        if (expectedMessageContains is not null)
+        {
+            var anyMatch = matchingCalls.Any(call =>
+            {
+                const int IndexOfLogMessage = 2;
+                var state = call.GetArguments()[IndexOfLogMessage];
+                return state?.ToString()?.Contains(expectedMessageContains) == true;
+            });
+
+            anyMatch
+                .Should()
+                .BeTrue(because: $"log message should contain '{expectedMessageContains}'");
+        }
+    }
+
+    private static MimeMessage MockEmail(string id = "1")
+    {
+        var message = new MimeMessage();
+        message.MessageId = id;
+        message.Date = DateTimeOffset.Now;
+        message.From.Add(new MailboxAddress("Martin Norén", "martinnoren@mymail.com"));
+        message.Subject = "Any subject";
+
+        var builder = new BodyBuilder
+        {
+            TextBody = "Hello world",
+            HtmlBody = "<p>Hello world</p>"
+        };
+
+        var attachmentBytes = Encoding.UTF8.GetBytes("fake pdf content");
+        builder.Attachments.Add("document.pdf", attachmentBytes, ContentType.Parse("application/pdf"));
+        message.Body = builder.ToMessageBody();
+
+        return message;
+    }
+
+    private static EmailInfo ExtractDataFromEmail(MimeMessage email)
+    {
+        var id = email.MessageId.ToIntOrDefault();
+        var dateSent = GetLocalTimeZone(email);
+        var from = email.From.Mailboxes.FirstOrDefault()?.ToString() ?? "Okänd avsändare";
+        var subject = email.Subject ?? string.Empty;
+        var plaintextBody = email.TextBody ?? string.Empty;
+        var htmlBody = email.HtmlBody ?? string.Empty;
+        var fileAttachments = GetAttachments(email);
+        
+        var result = new EmailInfo(id, dateSent, from, subject, plaintextBody, htmlBody);
+        result.FileAttachments.AddRange(fileAttachments);
+
+        return result;
+    }
+
+    private static string GetLocalTimeZone(MimeMessage email)
+    {
+        return TimeZoneInfo
+            .ConvertTimeBySystemTimeZoneId(email.Date.UtcDateTime, "Europe/Stockholm")
+            .ToString("yyyy-MM-dd HH:mm:ss");
+    }
+
+    private static List<FileAttachment> GetAttachments(MimeMessage email)
+    {
+        return email.Attachments
+            .OfType<MimePart>()
+            .Select(part =>
+            {
+                using var stream = new MemoryStream();
+                part.Content.DecodeTo(stream);
+                var data = Convert.ToBase64String(stream.ToArray());
+
+                return new FileAttachment(
+                    FileName: part.FileName ?? string.Empty,
+                    FileType: part.ContentType.MimeType ?? string.Empty,
+                    Description: string.Empty,
+                    Data: data
+                );
+            })
+            .Where(a => a.Validate())
+            .ToList();
+    }
+}

--- a/SN.UnitTests/SN.Application/GmailApplicationPasswordServiceTests.cs
+++ b/SN.UnitTests/SN.Application/GmailApplicationPasswordServiceTests.cs
@@ -156,27 +156,6 @@ public class GmailApplicationPasswordServiceTests : BaseTests
         }
     }
 
-    private static MimeMessage MockEmail(string id = "1")
-    {
-        var message = new MimeMessage();
-        message.MessageId = id;
-        message.Date = DateTimeOffset.Now;
-        message.From.Add(new MailboxAddress("Martin Norén", "martinnoren@mymail.com"));
-        message.Subject = "Any subject";
-
-        var builder = new BodyBuilder
-        {
-            TextBody = "Hello world",
-            HtmlBody = "<p>Hello world</p>"
-        };
-
-        var attachmentBytes = Encoding.UTF8.GetBytes("fake pdf content");
-        builder.Attachments.Add("document.pdf", attachmentBytes, ContentType.Parse("application/pdf"));
-        message.Body = builder.ToMessageBody();
-
-        return message;
-    }
-
     private static EmailInfo ExtractDataFromEmail(MimeMessage email)
     {
         var id = email.MessageId.ToIntOrDefault();

--- a/SN.UnitTests/SN.Application/GmailImapServiceTests.cs
+++ b/SN.UnitTests/SN.Application/GmailImapServiceTests.cs
@@ -1,0 +1,83 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using MailKit;
+using MailKit.Net.Imap;
+using MailKit.Search;
+using Microsoft.Extensions.Configuration;
+using MimeKit;
+using NSubstitute;
+using SN.Application.Dtos;
+using SN.Application.Interfaces;
+using SN.Application.Services;
+
+namespace SN.UnitTests.SN.Application;
+
+public class GmailImapServiceTests : BaseTests
+{
+    [Fact]
+    public async Task WhenNoUnreadEmailFound_AndNothingIsDownloaded_EmptyListIsReturnedToCallingMethod()
+    {
+        // Arrange
+        var (ioService, configuration, connectionClient) = MockInterfaces();
+
+        var uids = Enumerable.Empty<UniqueId>().ToList();
+        var client = Substitute.For<IImapClient>();
+        client.Inbox
+            .SearchAsync(Arg.Any<SearchQuery>())
+            .Returns(uids);
+        connectionClient
+            .ConnectAsync(Arg.Any<GoogleApplicationPasswordSecrets>())
+            .Returns(client);
+
+        var SUT = new GmailImapService(ioService, configuration, connectionClient);
+
+        // Act
+        var result = await SUT.DownloadEmails();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenUnreadEmailFound_AndIsDownloaded_ItIsReturnedToCallingMethod()
+    {
+        // Arrange
+        var (ioService, configuration, connectionClient) = MockInterfaces();
+
+        var uids = new List<UniqueId> { Fixture.Create<UniqueId>() }.As<IList<UniqueId>>();
+        var emailResult = MockEmail();
+        var client = Substitute.For<IImapClient>();
+        client.Inbox
+            .SearchAsync(Arg.Any<SearchQuery>())
+            .Returns(uids);
+        client.Inbox
+            .GetMessageAsync(Arg.Any<UniqueId>())
+            .Returns(emailResult);
+        connectionClient
+            .ConnectAsync(Arg.Any<GoogleApplicationPasswordSecrets>())
+            .Returns(client);
+
+        var SUT = new GmailImapService(ioService, configuration, connectionClient);
+        var expected = new List<MimeMessage>() { emailResult };
+
+
+        // Act
+        var result = await SUT.DownloadEmails();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(1);
+        result.Should().BeEquivalentTo(expected);
+    }
+
+    public (IIOService, IConfiguration, IImapConnectionClient) MockInterfaces()
+    {
+        var ioService = Substitute.For<IIOService>();
+        var configuration = Substitute.For<IConfiguration>();
+        configuration["Appsettings:GoogleImapCredentialsFilename"].Returns(Fixture.Create<string>());
+        var connectionClient = Substitute.For<IImapConnectionClient>();
+
+        return (ioService, configuration, connectionClient);
+    }
+}

--- a/SN.UnitTests/SN.Application/GmailInboxServiceTests.cs
+++ b/SN.UnitTests/SN.Application/GmailInboxServiceTests.cs
@@ -22,7 +22,7 @@ public class GmailInboxServiceTests : BaseTests
             .DownloadEmail(Arg.Any<string>())
             .Returns(Task.FromResult(message));
 
-        var SUT = new GmailInboxService(gmailApiService, gmailPayloadService, messageTypeService);
+        var SUT = new GmailOauth2Service(gmailApiService, gmailPayloadService, messageTypeService);
 
         // Act
         var result = await SUT.CheckForEmails();

--- a/SN.UnitTests/SN.Application/GmailOauth2ServiceTests.cs
+++ b/SN.UnitTests/SN.Application/GmailOauth2ServiceTests.cs
@@ -1,4 +1,5 @@
 ﻿using AutoFixture;
+using FluentAssertions;
 using Google.Apis.Gmail.v1.Data;
 using NSubstitute;
 using SN.Application.Interfaces;
@@ -7,8 +8,19 @@ using SN.UnitTests.Factories;
 
 namespace SN.UnitTests.SN.Application;
 
-public class GmailInboxServiceTests : BaseTests
+public class GmailOauth2ServiceTests : BaseTests
 {
+    [Fact]
+    public async Task StrategyProperty_WhenCalled_ReturnsCorrectValue()
+    {
+        // Assign
+        var (gmailApiService, gmailPayloadService, messageTypeService) = SetupDependencies();
+        var SUT = new GmailOauth2Service(gmailApiService, gmailPayloadService, messageTypeService);
+
+        // Act & Assert
+        SUT.strategy.Should().Be("BrowserAuthentication");
+    }
+
     [Fact]
     public async Task CheckForEmails_WhenEmailContainsHtmlAndPlainTextAndPdfAttachment_EmailMessageBuiltUponHtmlTextAndPdfAttachmentIsFetched()
     {

--- a/SN.UnitTests/SN.Application/MessageForwarderServiceTests.cs
+++ b/SN.UnitTests/SN.Application/MessageForwarderServiceTests.cs
@@ -1,48 +1,78 @@
 ﻿using AutoFixture;
 using FluentAssertions;
-using NSubstitute;
-using System.Text;
-using SN.Application.Interfaces;
-using SN.Application.Dtos;
-using SN.Application.Services;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SN.Application.Dtos;
+using SN.Application.Interfaces;
+using SN.Application.Services;
+using System.Text;
 
 namespace SN.UnitTests.SN.Application;
 
 public class MessageForwarderServiceTests : BaseTests
 {
     [Fact]
-    public async Task WhenFetchFromGmail_AndNoEmails_ThenEarlyExitIsMade()
+    public async Task WhenStrategy_IsNotMatching_ThenEarlyExitIsMadeWithLogging()
     {
         // Assign
-        var gmailInboxService = SetupInboxService(Enumerable.Empty<EmailInfo>().ToList());
+        var gmailServices = SetupInboxService(Enumerable.Empty<EmailInfo>().ToList());
         var slackService = Fixture.Freeze<ISlackService>();
         var logger = Substitute.For<ILogger<MessageForwarderService>>();
-        var SUT = new MessageForwarderService(gmailInboxService, slackService, logger);
+        var configuration = Substitute.For<IConfiguration>();
+        var nonMatchingStrategy = Fixture.Create<string>();
+        configuration["GmailStrategy"].Returns(nonMatchingStrategy);
+        var SUT = new MessageForwarderService(configuration, gmailServices, slackService, logger);
+        var expectedLogMessage = $"---> Strategy '{nonMatchingStrategy}' not found.";
 
         // Act
         await SUT.Run();
 
         // Assert
-        AssertLogReceived(1, LogLevel.Information, logger);
+        AssertLogReceived(1, LogLevel.Warning, logger, expectedLogMessage);
         await slackService.Received(0).SendMessage(Arg.Any<List<EmailInfo>>());
     }
 
     [Fact]
-    public async Task WhenFetchFromGmail_AndNEmailsExist_ThenSlackServiceIsCalledAndTrueIsReturned()
+    public async Task WhenFetchFromGmail_AndNoEmails_ThenEarlyExitIsMade()
     {
         // Assign
-        var gmailInboxService = SetupInboxService(Fixture.CreateMany<EmailInfo>(1).ToList());
+        var gmailServices = SetupInboxService(Enumerable.Empty<EmailInfo>().ToList());
         var slackService = Fixture.Freeze<ISlackService>();
         var logger = Substitute.For<ILogger<MessageForwarderService>>();
-        var SUT = new MessageForwarderService(gmailInboxService, slackService, logger);
+        var configuration = Substitute.For<IConfiguration>();
+        configuration["GmailStrategy"].Returns("Headless");
+        var SUT = new MessageForwarderService(configuration, gmailServices, slackService, logger);
 
         // Act
         await SUT.Run();
 
         // Assert
-        AssertLogReceived(1, LogLevel.Information, logger);
+        AssertLogReceived(1, LogLevel.Information, logger, "---> No new emails found.");
+        await slackService.Received(0).SendMessage(Arg.Any<List<EmailInfo>>());
+    }
+
+    [Fact]
+    public async Task WhenFetchFromGmail_AndOneEmailExist_ThenSlackServiceIsCalledAndLoggingIsDone()
+    {
+        // Assign
+        var emails = Fixture.Build<EmailInfo>()
+                .CreateMany(1)
+                .ToList();
+
+        var gmailServices = SetupInboxService(emails);
+        var slackService = Fixture.Freeze<ISlackService>();
+        var logger = Substitute.For<ILogger<MessageForwarderService>>();
+        var configuration = Substitute.For<IConfiguration>();
+        configuration["GmailStrategy"].Returns("Headless");
+        var SUT = new MessageForwarderService(configuration, gmailServices, slackService, logger);
+
+        // Act
+        await SUT.Run();
+
+        // Assert
+        AssertLogReceived(1, LogLevel.Information, logger, $"---> 1 email(s) forwarded to Slack.");
         await slackService.Received(1).SendMessage(Arg.Any<List<EmailInfo>>());
     }
 
@@ -62,19 +92,24 @@ public class MessageForwarderServiceTests : BaseTests
             "www.avast.com",
         };
         var text = new StringBuilder();
-        foreach (string s in unexpecedStrings) { text.AppendLine(s); }
+        foreach (string s in unexpecedStrings) 
+        { 
+            text.AppendLine(s); 
+        }
 
-        var gmailInboxService = SetupInboxService(Fixture.Build<EmailInfo>()
+        var emails = Fixture.Build<EmailInfo>()
                 .With(x => x.PlainTextBody, text.ToString())
                 .CreateMany(1)
-            .ToList());
-
+                .ToList();
+        var gmailServices = SetupInboxService(emails);
+        
         var slackService = Fixture.Freeze<ISlackService>();
         List<EmailInfo> capturedMessages = null;
         await slackService.SendMessage(Arg.Do<List<EmailInfo>>(x => capturedMessages = x));
-
         var logger = Substitute.For<ILogger<MessageForwarderService>>();
-        var SUT = new MessageForwarderService(gmailInboxService, slackService, NullLogger<MessageForwarderService>.Instance);
+        var configuration = Substitute.For<IConfiguration>();
+        configuration["GmailStrategy"].Returns("Headless");
+        var SUT = new MessageForwarderService(configuration, gmailServices, slackService, NullLogger<MessageForwarderService>.Instance);
 
         // Act
         await SUT.Run();
@@ -83,29 +118,65 @@ public class MessageForwarderServiceTests : BaseTests
         await slackService
             .Received(1)
             .SendMessage(Arg.Any<List<EmailInfo>>());
+        
         CountOccurenciesOfTextStringsInText(unexpecedStrings, capturedMessages)
             .Should()
             .Be(0);
     }
 
-    private void AssertLogReceived(int amount, LogLevel logLevel, ILogger<MessageForwarderService> logger)
+    private void AssertLogReceived(
+    int amount,
+    LogLevel logLevel,
+    ILogger<MessageForwarderService> logger,
+    string expectedMessageContains = null)
     {
-        logger.Received(amount).Log(
-            logLevel,
-            Arg.Any<EventId>(),
-            Arg.Any<object>(),
-            Arg.Any<Exception?>(),
-            Arg.Any<Func<object, Exception?, string>>()
-        );
+        var matchingCalls = logger.ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name == "Log")
+            .Where(call =>
+            {
+                var args = call.GetArguments();
+                return args[0] is LogLevel level && level == logLevel;
+            })
+            .ToList();
+
+        matchingCalls.Should().HaveCount(amount);
+
+        if (expectedMessageContains is not null)
+        {
+            var anyMatch = matchingCalls.Any(call =>
+            {
+                const int IndexOfLogMessage = 2;
+                var state = call.GetArguments()[IndexOfLogMessage];
+                return state?.ToString()?.Contains(expectedMessageContains) == true;
+            });
+
+            anyMatch
+                .Should()
+                .BeTrue(because: $"log message should contain '{expectedMessageContains}'");
+        }
     }
 
-    private IGmailInboxService SetupInboxService(List<EmailInfo> emailInfos)
+    private IEnumerable<IGmailInboxService> SetupInboxService(List<EmailInfo> emailInfos)
     {
-        var gmailInboxService = Fixture.Freeze<IGmailInboxService>();
-        gmailInboxService.CheckForEmails()
+        var gmailApiService = Substitute.For<IGmailInboxService>();
+        gmailApiService
+            .strategy
+            .Returns(Fixture.Create<string>());
+        var gmalImapService = Substitute.For<IGmailInboxService>();
+        gmailApiService
+            .CheckForEmails()
             .Returns(emailInfos);
+        gmailApiService
+            .strategy
+            .Returns("Headless");
 
-        return gmailInboxService;
+        var result = new List<IGmailInboxService> 
+        {
+            gmailApiService,
+            gmalImapService
+        };
+
+        return result;
     }
 
     private static int CountOccurenciesOfTextStringsInText(List<string> unexpecedStrings, List<EmailInfo> capturedMessages)


### PR DESCRIPTION
Feature:
- Supports headless execution via Google App Passwords, removing the requirement for browser-based OAuth2 authorization flows (default setting).
- Option: Supports switching back to browser-based OAuth2 authorization by changing the value in appsettings.json (section GmailStrategy) to "BrowserAuthentication".