### PR TITLE
fix: disable DinD TLS, use port 2375

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,11 +35,10 @@ docker:
     - name: docker:27-dind
       alias: docker
   variables:
-    DOCKER_TLS_CERTDIR: "/certs"
-    DOCKER_HOST: "tcp://docker:2376"
-    DOCKER_TLS_VERIFY: "1"
-    DOCKER_CERT_PATH: "/certs/client"
+    DOCKER_TLS_CERTDIR: ""
+    DOCKER_HOST: "tcp://docker:2375"
   before_script:
+    - sleep 5
     - mkdir -p /etc/docker/certs.d/192.168.50.6
     - cp /etc/ssl/certs/harbor/harbor.crt /etc/docker/certs.d/192.168.50.6/ca.crt
     - echo "$HARBOR_PASSWORD" | docker login $HARBOR_REGISTRY --username "$HARBOR_USER" --password-stdin


### PR DESCRIPTION
DinD TLS certs not ready before client connects.
Disable TLS between client and DinD since they
run in the same isolated pod.